### PR TITLE
[hotfix] 修复喵板的can FIFO配置,关闭自动重发功能

### DIFF
--- a/boards/damiao/mc02/damiao_mc02.dts
+++ b/boards/damiao/mc02/damiao_mc02.dts
@@ -243,6 +243,8 @@
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>,
              <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+    reg = <0x4000a000 0x400>, <0x4000ac00 0x2800>;
+    bosch,mram-cfg = <0x0 1 0 32 0 0 32 32>;
     pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
     pinctrl-names = "default";
 };
@@ -251,6 +253,8 @@
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>,
              <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+    reg = <0x4000a400 0x400>, <0x4000ac00 0x2800>;
+    bosch,mram-cfg = <0x600 1 0 32 0 0 32 32>;
     pinctrl-0 = <&fdcan2_rx_pb5 &fdcan2_tx_pb6>;
     pinctrl-names = "default";
 };
@@ -259,6 +263,8 @@
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>,
              <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+    reg = <0x4000d400 0x400>, <0x4000ac00 0x2800>;
+    bosch,mram-cfg = <0xc00 1 0 32 0 0 32 32>;
     pinctrl-0 = <&fdcan3_rx_pd12 &fdcan3_tx_pd13>;
     pinctrl-names = "default";
 };

--- a/drivers/can_tx_manager/can_tx_manager.c
+++ b/drivers/can_tx_manager/can_tx_manager.c
@@ -73,6 +73,10 @@ int rp_can_tx_manager_init(const struct device *dev)
         return -EINVAL;
     }
 
+    can_stop(cfg->can_dev);
+    can_set_mode(cfg->can_dev, CAN_MODE_NORMAL | CAN_MODE_ONE_SHOT);    // 关闭自动重发
+    can_start(cfg->can_dev);
+
     (void)cfg;
     memset(&data->sender_list, 0, sizeof(data->sender_list));
     memset(&data->can_items, 0, sizeof(data->can_items));


### PR DESCRIPTION
1. 关闭自动重发模式，避免占用FIFO
2. 重新分配喵板can的ram，每一路一个硬件过滤器，32个rx FIFO，32个tx FIFO