### PR TITLE
feat(dts): add uart7/8/9 support and fix dma configs for usart1/spi2

### DIFF
--- a/boards/damiao/mc02/damiao_mc02.dts
+++ b/boards/damiao/mc02/damiao_mc02.dts
@@ -134,7 +134,7 @@
                <&gpioc 3 GPIO_ACTIVE_LOW>;
     dmas =  <&dmamux1 1 40 STM32_DMA_PERIPH_TX>,    // TX: DMA1 Stream 1, request 40
     <&dmamux1 4 39 STM32_DMA_PERIPH_RX>;    // RX: DMA1 Stream 4, request 39
-    dma-names = "spi1-tx", "spi1-rx";
+    dma-names = "tx", "rx";
 
     bmi08x_accel: bmi08x@0 {
         compatible = "bosch,bmi08x-accel";
@@ -217,7 +217,7 @@
     pinctrl-names = "default";
     dmas =  <&dmamux1 10 42 STM32_DMA_PERIPH_TX>,   // TX: DMA2 Stream 2, request 42
     <&dmamux1 9 41 STM32_DMA_PERIPH_RX>;   // RX: DMA2 Stream 1, request 41
-    dma-names = "usart1-tx", "usart1-rx";
+    dma-names = "tx", "rx";
     fifo-enable;
 };
 

--- a/boards/damiao/mc02/damiao_mc02.dts
+++ b/boards/damiao/mc02/damiao_mc02.dts
@@ -257,13 +257,43 @@
     stop-bits = "1";
 };
 
+&uart7 {
+    status = "okay";
+    clocks = <&rcc STM32_CLOCK(APB1, 30)>,
+             <&rcc STM32_SRC_PLL2_Q USART2345678_SEL(1)>;
+    pinctrl-0 = <&uart7_rx_pe7 &uart7_tx_pe8>;
+    pinctrl-names = "default";
+    fifo-enable;
+};
+
+&uart8 {
+    status = "okay";
+    clocks = <&rcc STM32_CLOCK(APB1, 31)>,
+             <&rcc STM32_SRC_PLL2_Q USART2345678_SEL(1)>;
+    pinctrl-0 = <&uart8_rx_pe0 &uart8_tx_pe1>;
+    pinctrl-names = "default";
+    fifo-enable;
+};
+
+&uart9 {
+    status = "okay";
+    clocks = <&rcc STM32_CLOCK(APB2, 6)>,
+             <&rcc STM32_SRC_PLL2_Q USART16_SEL(1)>;
+    pinctrl-0 = <&uart9_rx_pd14 &uart9_tx_pd15>;
+    pinctrl-names = "default";
+    fifo-enable;
+};
+
 &usart10 {
     status = "okay";
+    clocks = <&rcc STM32_CLOCK(APB2, 7)>,
+             <&rcc STM32_SRC_PLL2_Q USART16_SEL(1)>;
+    pinctrl-0 = <&usart10_rx_pe2 &usart10_tx_pe3>;
+    pinctrl-names = "default";
     dmas =  <&dmamux1 5 119 STM32_DMA_PERIPH_TX>,    // TX: DMA1 Stream 5, request 119
     <&dmamux1 6 118 STM32_DMA_PERIPH_RX>;    // RX: DMA1 Stream 6, request 118
     dma-names = "tx", "rx";
-    pinctrl-0 = <&usart10_rx_pe2 &usart10_tx_pe3>;
-    pinctrl-names = "default";
+    fifo-enable;
 };
 
 &fdcan1 {


### PR DESCRIPTION
1. 新增 串口 7, 8, 9 配置，未配置 dma
2. 修正 串口 10 时钟配置
3. 修正 串口 1 和 SPI2 设备树节点属性 dma-names 命名