### PR TITLE
fix rm电机驱动和增加头文件保护

### DIFF
--- a/drivers/bldcm/dji/can_dji.c
+++ b/drivers/bldcm/dji/can_dji.c
@@ -125,7 +125,7 @@ static int motor_dji_can_tx_fillbuffer_handler(struct can_frame *frame, void *us
             frame->dlc = 8;
             frame->flags = 0;
             k_spinlock_key_t key = k_spin_lock(&data->lock);
-            int diff = cfg->rx_id & 0x0F;   // 或者写成 cfg->rx_id % 16
+            int diff = cfg->rx_id % 16;
             if (diff <= 0 || diff > 8) {
                 LOG_ERR("[dji_motor_err] tx handle invalid id difference: tx_id=%d, rx_id=%d", cfg->tx_id, cfg->rx_id);
                 k_spin_unlock(&data->lock, key);

--- a/drivers/bldcm/dji/can_dji.c
+++ b/drivers/bldcm/dji/can_dji.c
@@ -125,7 +125,7 @@ static int motor_dji_can_tx_fillbuffer_handler(struct can_frame *frame, void *us
             frame->dlc = 8;
             frame->flags = 0;
             k_spinlock_key_t key = k_spin_lock(&data->lock);
-            int diff = cfg->rx_id % 10;
+            int diff = cfg->rx_id & 0x0F;   // 或者写成 cfg->rx_id % 16
             if (diff <= 0 || diff > 8) {
                 LOG_ERR("[dji_motor_err] tx handle invalid id difference: tx_id=%d, rx_id=%d", cfg->tx_id, cfg->rx_id);
                 k_spin_unlock(&data->lock, key);

--- a/include/drivers/motor.h
+++ b/include/drivers/motor.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <zephyr/device.h>
 #include <math.h>
 #include <errno.h>


### PR DESCRIPTION
1.rm电机驱动,发送报文格式维修
2.motor.h增加头文件保护,防止二次包含