### PR TITLE
fix修复cmake的语法,解决之前定义CONFIG_REMOTE链接不到头文件

### DIFF
--- a/drivers/remote/CMakeLists.txt
+++ b/drivers/remote/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(DR16_REMOTE, dr16_remote.c)
+zephyr_library_sources_ifdef(CONFIG_DR16_REMOTE dr16_remote.c)

--- a/drivers/remote/dr16_remote.c
+++ b/drivers/remote/dr16_remote.c
@@ -156,7 +156,7 @@ static void rc_sensor_check(rc_sensor_t* sensor) {
   }
 
   if ((info->thumbwheel.value == 0) && (thumbwheel_record != 0)) {
-    for (char i = 0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
       if (info->tw_step_value[i] > 0 && thumbwheel_record > 0) {
         if (thumbwheel_record >= info->tw_step_value[i]) {
           info->thumbwheel.step[i] = !info->thumbwheel.step[i];
@@ -504,10 +504,11 @@ static bool rc_is_death_zone(int16_t value, int16_t center, int16_t threshold) {
   return !(value > center + threshold || value < center - threshold);
 }
 
-static bool rc_is_channel_reset(rc_sensor_info_t* info) {
-  return ((!rc_is_death_zone(info->ch0, 0, 50)) &&
+static bool __attribute__((unused)) rc_is_channel_reset(rc_sensor_info_t *info)
+{
+	return ((!rc_is_death_zone(info->ch0, 0, 50)) &&
           (!rc_is_death_zone(info->ch1, 0, 50)) &&
-          (!rc_is_death_zone(info->ch2, 0, 50)) &&
+		      (!rc_is_death_zone(info->ch2, 0, 50)) &&
           (!rc_is_death_zone(info->ch3, 0, 50)));
 }
 

--- a/samples/boards/dm_mc02/remote/CMakeLists.txt
+++ b/samples/boards/dm_mc02/remote/CMakeLists.txt
@@ -10,7 +10,6 @@ list(APPEND DTC_BINDINGS_DIRS
 
 target_sources(app PRIVATE
     src/main.c
-    ${self_driver_DIR}/remote/dr16_remote.c
 )
 target_include_directories(app PRIVATE include)
 


### PR DESCRIPTION
1.fix修复cmake的语法,解决之前定义CONFIG_REMOTE链接不到头文件
2.解决编译会有warming